### PR TITLE
Added XmlMessageLogPlugin

### DIFF
--- a/fiscalhr/fiscal.py
+++ b/fiscalhr/fiscal.py
@@ -515,18 +515,18 @@ class VerifiedHTTPSHandler(urllib2.HTTPSHandler):
 
 
 class XmlMessageLogPlugin(MessagePlugin):
-    """
-    '''Suds message plugin for logging request and response XML body'''
-    """
+    '''
+    Suds message plugin for logging request and response XML body
+    '''
 
     def __init__(self, sending_log_callback=None, received_log_callback=None):
         self.sending_log_callback = sending_log_callback
         self.received_log_callback = received_log_callback
 
     def sending(self, context):
-        if self.sending_log_callback is not None:
+        if self.sending_log_callback:
             self.sending_log_callback(unicode(context.envelope))
 
     def received(self, context):
-        if self.received_log_callback is not None:
+        if self.received_log_callback:
             self.received_log_callback(unicode(context.reply))


### PR DESCRIPTION
Added logging plugin which serves as a replacement for removed Suds Client 'last_sent' and 'last_received' methods from https://bitbucket.org/jurko/suds fork (check version 0.4.1 jurko 5, 2013-11-11).
Useful for storing XML messages via callback methods.